### PR TITLE
Improve prize resolution to sync wheel and modal

### DIFF
--- a/apps/web/src/components/wheel/types.ts
+++ b/apps/web/src/components/wheel/types.ts
@@ -4,6 +4,11 @@ export interface WheelSegment {
   color: string;
   iconUrl?: string;
   isWinning?: boolean;
+  /**
+   * Optional original position index coming from the backend configuration.
+   * This helps map API responses back to the exact frontend segment.
+   */
+  position?: number;
 }
 
 export interface WheelConfig {

--- a/apps/web/src/pages/PlayWheel.tsx
+++ b/apps/web/src/pages/PlayWheel.tsx
@@ -76,6 +76,19 @@ type PlayResponse = {
   slot: {
     id: string;
     label: string;
+    position?: number;
+  };
+  /**
+   * Frontend-resolved information to keep the UI in sync with the wheel animation.
+   * These fields are not guaranteed to exist in the backend response but allow
+   * us to normalise what we display to the player.
+   */
+  resolvedPrizeIndex?: number;
+  resolvedSegment?: {
+    id: string;
+    label: string;
+    isWinning?: boolean;
+    position?: number;
   };
 };
 
@@ -564,6 +577,9 @@ const PlayWheel = () => {
   // Add a confetti ref to control it
   const confettiRef = useRef<any>(null);
 
+  // Helper to always reference the segment label that visually won on the wheel
+  const resolvedWinningLabel = state.spinResult?.resolvedSegment?.label ?? state.spinResult?.slot.label ?? '';
+
   // Fetch wheel data
   const {
     data: wheelData,
@@ -688,11 +704,12 @@ const PlayWheel = () => {
         ];
 
         // Use default slots for display purposes - CRITICAL: Include id field
-        const segments = defaultSlots.map((slot) => ({
-          id: slot.id,
+        const segments = defaultSlots.map((slot, index) => ({
+          id: String(slot.id),
           label: slot.label,
           color: slot.color || (slot.isWinning ? '#28a745' : '#dc3545'),
           isWinning: slot.isWinning,
+          position: typeof slot.position === 'number' ? slot.position : index,
         }));
 
         dispatch({ type: 'SET_WHEEL_CONFIG', payload: {
@@ -717,12 +734,16 @@ const PlayWheel = () => {
         }
 
         // Set wheel colors and prepare segments configuration
-        const segments = sortedSlots.map((slot) => ({
-          id: slot.id,
-          label: slot.label,
-          color: slot.color || (slot.isWinning ? '#28a745' : '#dc3545'),
-          isWinning: slot.isWinning,
-        }));
+        const segments = sortedSlots.map((slot, index) => {
+          const normalizedId = slot.id != null ? String(slot.id) : `slot-${index}`;
+          return {
+            id: normalizedId,
+            label: slot.label,
+            color: slot.color || (slot.isWinning ? '#28a745' : '#dc3545'),
+            isWinning: slot.isWinning,
+            position: typeof slot.position === 'number' ? slot.position : index,
+          };
+        });
 
         // 🔥 RUNTIME GUARD: Log segment order and verify consistent sorting
         const frontendSegmentOrder = segments.map((seg, index) => ({
@@ -1001,77 +1022,117 @@ const PlayWheel = () => {
   const handleSpinResultWithData = (data: any) => {
     console.log('🎯 PlayWheel: Backend response data:', JSON.parse(JSON.stringify(data)));
 
-    // CRITICAL FIX: Always use slot.id as the primary source of truth
-    let prizeIndexToUse = 0; // Default fallback
+    const segments = state.wheelConfig.segments ?? [];
+    const safeSegmentsLength = segments.length;
 
-    // First: Try to find the segment by slot.id (most reliable)
-    if (data?.slot?.id) {
-      const byId = state.wheelConfig.segments.findIndex((segment) => segment.id === data.slot.id);
-      if (byId !== -1) {
-        prizeIndexToUse = byId;
-        console.log('✅ Found segment by slot.id:', { slotId: data.slot.id, prizeIndex: prizeIndexToUse });
-      } else {
-        console.error('❌ slot.id not found in segments!', {
-          slotId: data.slot.id,
-          segmentIds: state.wheelConfig.segments.map(s => s.id),
-          fallbackToBackendIndex: data.prizeIndex
-        });
-        // If slot.id mapping fails, use backend's prizeIndex directly
-        if (typeof data.prizeIndex === 'number') {
-          prizeIndexToUse = data.prizeIndex;
-          console.log('⚠️ Using backend prizeIndex as fallback:', prizeIndexToUse);
+    const normalizeId = (value: unknown): string | null => {
+      if (value === null || value === undefined) {
+        return null;
+      }
+      try {
+        return String(value);
+      } catch {
+        return null;
+      }
+    };
+
+    const normalizedSlotId = normalizeId(data?.slot?.id);
+    const normalizedSlotLabel = typeof data?.slot?.label === 'string'
+      ? data.slot.label.trim().toLowerCase()
+      : null;
+    const normalizedSlotPosition = typeof data?.slot?.position === 'number'
+      ? data.slot.position
+      : null;
+
+    const clampIndex = (index: number): number => {
+      if (!Number.isFinite(index) || safeSegmentsLength === 0) {
+        return 0;
+      }
+      return Math.max(0, Math.min(safeSegmentsLength - 1, Math.trunc(index)));
+    };
+
+    const findSegmentIndex = (): number => {
+      if (safeSegmentsLength === 0) {
+        return 0;
+      }
+
+      if (normalizedSlotId) {
+        const byId = segments.findIndex((segment) => normalizeId(segment.id) === normalizedSlotId);
+        if (byId !== -1) {
+          return byId;
         }
       }
-    } else {
-      console.error('❌ No slot.id in backend response!');
-      // If no slot.id, use backend's prizeIndex
-      if (typeof data.prizeIndex === 'number') {
-        prizeIndexToUse = data.prizeIndex;
-        console.log('⚠️ No slot.id; using backend prizeIndex:', prizeIndexToUse);
+
+      if (normalizedSlotPosition !== null) {
+        const byPosition = segments.findIndex((segment) => typeof segment.position === 'number' && segment.position === normalizedSlotPosition);
+        if (byPosition !== -1) {
+          return byPosition;
+        }
       }
-    }
 
-    // Clamp to valid bounds
-    const segCount = state.wheelConfig.segments.length;
-    if (segCount > 0) {
-      prizeIndexToUse = Math.max(0, Math.min(segCount - 1, prizeIndexToUse));
-    }
+      if (normalizedSlotLabel) {
+        const byLabel = segments.findIndex((segment) => segment.label?.trim().toLowerCase() === normalizedSlotLabel);
+        if (byLabel !== -1) {
+          return byLabel;
+        }
+      }
 
-    console.log('🎯 Final prizeIndex to use:', prizeIndexToUse);
-    
-    // Log which segment this prizeIndex corresponds to
-    if (state.wheelConfig.segments && state.wheelConfig.segments.length > prizeIndexToUse) {
-      const targetSegment = state.wheelConfig.segments[prizeIndexToUse];
-      console.log('🎯 Target segment:', {
-        index: prizeIndexToUse,
-        id: targetSegment.id,
-        label: targetSegment.label,
-        isWinning: targetSegment.isWinning
-      });
-    }
-    
-    // 🔥 PRIZE INDEX DEBUG: Enhanced logging for mismatch detection
-    console.log('🎯 PRIZE INDEX DEBUG:', {
-      backendPrizeIndex: data.prizeIndex,
-      backendSlotId: data.slot.id,
-      backendSlotLabel: data.slot.label,
-      frontendSegmentIds: state.wheelConfig.segments.map(s => s.id),
-      frontendSegmentLabels: state.wheelConfig.segments.map(s => s.label),
-      resolvedIndex: prizeIndexToUse,
-      targetSegment: state.wheelConfig.segments[prizeIndexToUse]?.label,
-      isMismatch: data.slot.label !== state.wheelConfig.segments[prizeIndexToUse]?.label
+      if (typeof data?.prizeIndex === 'number') {
+        const backendIndex = clampIndex(data.prizeIndex);
+        if (backendIndex >= 0 && backendIndex < safeSegmentsLength) {
+          return backendIndex;
+        }
+      }
+
+      return 0;
+    };
+
+    const resolvedPrizeIndex = clampIndex(findSegmentIndex());
+    const resolvedSegment = safeSegmentsLength > 0 ? segments[resolvedPrizeIndex] ?? null : null;
+
+    console.log('🎯 Prize resolution summary:', {
+      backendPrizeIndex: data?.prizeIndex,
+      backendSlotId: data?.slot?.id,
+      backendSlotLabel: data?.slot?.label,
+      backendSlotPosition: data?.slot?.position,
+      resolvedPrizeIndex,
+      resolvedSegmentId: resolvedSegment?.id,
+      resolvedSegmentLabel: resolvedSegment?.label,
     });
-    
-    dispatch({ type: 'SET_SPIN_RESULT', payload: data });
-    dispatch({ type: 'SET_PRIZE_INDEX', payload: prizeIndexToUse });
-    // Freeze current segments to avoid any reordering during animation
-    if (state.wheelConfig.segments && state.wheelConfig.segments.length > 0) {
-      setSpinSegmentsSnapshot([...state.wheelConfig.segments]);
+
+    const normalizedSlotIdForResult = normalizeId(resolvedSegment?.id) ?? normalizedSlotId ?? '';
+    const normalizedSlotLabelForResult = resolvedSegment?.label ?? (typeof data?.slot?.label === 'string' ? data.slot.label : '');
+    const normalizedSlotPositionForResult =
+      typeof resolvedSegment?.position === 'number'
+        ? resolvedSegment.position
+        : normalizedSlotPosition ?? undefined;
+
+    const normalizedResult: PlayResponse = {
+      ...data,
+      slot: {
+        ...data?.slot,
+        id: normalizedSlotIdForResult,
+        label: normalizedSlotLabelForResult,
+        position: normalizedSlotPositionForResult,
+      },
+      resolvedPrizeIndex,
+      resolvedSegment: resolvedSegment
+        ? {
+            id: normalizeId(resolvedSegment.id) ?? normalizedSlotIdForResult,
+            label: resolvedSegment.label,
+            isWinning: resolvedSegment.isWinning,
+            position: resolvedSegment.position,
+          }
+        : undefined,
+    };
+
+    dispatch({ type: 'SET_SPIN_RESULT', payload: normalizedResult });
+    dispatch({ type: 'SET_PRIZE_INDEX', payload: resolvedPrizeIndex });
+    if (safeSegmentsLength > 0) {
+      setSpinSegmentsSnapshot([...segments]);
     }
     dispatch({ type: 'SET_MUST_SPIN', payload: true });
 
-    // 🔥 Timeout mechanism: show result only after the wheel should have finished
-    // Clear any existing timeouts first
     if (window.fallbackTimeout) {
       clearTimeout(window.fallbackTimeout);
       window.fallbackTimeout = null;
@@ -1080,8 +1141,6 @@ const PlayWheel = () => {
       clearTimeout(window.immediateFallback);
       window.immediateFallback = null;
     }
-
-    // Fallback is now scheduled when the wheel animation actually starts, using its true duration
   };
 
   // Debug effect to monitor mustSpin state changes
@@ -1181,7 +1240,7 @@ const PlayWheel = () => {
       email: data.email,
       phone: data.phone || '',
       playId: state.spinResult?.play.id || '',
-      prize: state.spinResult?.slot.label || '',
+      prize: resolvedWinningLabel || '',
       timestamp: new Date().toISOString(),
     } });
 
@@ -1313,7 +1372,7 @@ const PlayWheel = () => {
     // Otherwise, if there's a PIN, generate a QR code
     else if (state.spinResult.play.prize.pin) {
       const pin = state.spinResult.play.prize.pin;
-      const prizeInfo = `Prize: ${state.spinResult.slot.label}, PIN: ${pin}`;
+      const prizeInfo = `Prize: ${resolvedWinningLabel}, PIN: ${pin}`;
       const encodedPrizeInfo = encodeURIComponent(prizeInfo);
 
       // Use Google Charts API for QR code generation
@@ -1331,7 +1390,8 @@ const PlayWheel = () => {
       // Create a temporary link element
       const link = document.createElement('a');
       link.href = qrUrl;
-      link.download = `prix-${state.spinResult.slot.label.replace(/\s+/g, '-').toLowerCase()}.png`;
+      const downloadLabel = (resolvedWinningLabel || 'prize').replace(/\s+/g, '-').toLowerCase();
+      link.download = `prix-${downloadLabel}.png`;
 
       // Append to the body, click, and remove
       document.body.appendChild(link);
@@ -1724,7 +1784,7 @@ const PlayWheel = () => {
             {state.spinResult?.play.result === 'WIN' ? (
               <>
                 <p className="text-base sm:text-lg text-gray-700 mb-4">
-                  Vous avez gagné : <strong>{state.spinResult.slot.label}</strong>
+                  Vous avez gagné : <strong>{resolvedWinningLabel}</strong>
                 </p>
                 <div className="bg-blue-50 p-3 sm:p-4 rounded-lg">
                   <p className="text-sm sm:text-base text-blue-800 font-medium">


### PR DESCRIPTION
## Summary
- preserve backend slot ordering metadata on wheel segments by carrying their original position ids
- resolve the winning segment using id, position or label fallbacks so the modal always mirrors the pointer

## Testing
- pnpm --filter web lint *(fails: repository contains thousands of existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d0964239f0832487772a602bf0d21c