### PR TITLE
Align prize metadata with pointer position

### DIFF
--- a/apps/web/src/components/wheel/types.ts
+++ b/apps/web/src/components/wheel/types.ts
@@ -4,6 +4,29 @@ export interface WheelSegment {
   color: string;
   iconUrl?: string;
   isWinning?: boolean;
+  /**
+   * Optional original position index coming from the backend configuration.
+   * This helps map API responses back to the exact frontend segment.
+   */
+  position?: number;
+}
+
+export interface WheelSpinResult {
+  /**
+   * Zero-based index of the segment detected under the physical pointer when
+   * the animation finished. Always clamped to the available segment range.
+   */
+  pointerIndex: number;
+  /**
+   * Zero-based index that the consumer requested for the spin. Allows the
+   * caller to detect and react to any discrepancies.
+   */
+  expectedIndex: number;
+  /**
+   * Indicates whether the detected pointer index already matched the expected
+   * index without needing any consumer-side correction.
+   */
+  isAligned: boolean;
 }
 
 export interface WheelConfig {


### PR DESCRIPTION
## Summary
- add a typed spin result payload so the wheel component can report which segment actually sits under the pointer when an animation completes
- surface the pointer index in the parent page and reconcile the stored spin result, modal copy, and prize claim metadata with the detected segment
- feed the pointer summary back into the existing wheel flow so the UI reuses the corrected prize index while keeping the fallback timers intact

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68d0964239f0832487772a602bf0d21c